### PR TITLE
Specify that Sitincator must be run from `Sitincator/resources/app` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To install the binary:
 - Start the application: `/home/pi/Sitincator/Sitincator`
 - You are asked to enter the calendar ID (the calendar ID can be found on the settings page of your calendar in Google Calendar)
 - Open the link printed in your terminal, login with the same user as before to obtain the OAuth JSON file and authorize the app to access Google's API. You now get a token in the browser. Enter that token in the terminal's prompt.
+- If your Raspberry Pi is not already in portrait mode, append the following to your `/boot/config.txt`: `display_rotate=1 90 degrees`
 
 #### Start the Application
 


### PR DESCRIPTION
The app will not display properly if the Raspberry Pi is in landscape mode, added instructions to "Configuration" in the readme for setting portrait mode on a pi